### PR TITLE
Webpack support - don't use require.resolve(), allow user to use it

### DIFF
--- a/src/renderer-require.js
+++ b/src/renderer-require.js
@@ -41,7 +41,7 @@ const BrowserWindow = process.type === 'renderer' ?
  */
 export async function rendererRequireDirect(modulePath, timeout=240*1000) {
   let bw = new BrowserWindow({width: 500, height: 500, show: false});
-  let fullPath = require.resolve(modulePath);
+  let fullPath = modulePath;
 
   let ready = Observable.merge(
     fromRemoteWindow(bw, 'did-finish-load', true),


### PR DESCRIPTION
The README and in-code comment instructs users they may need to use
require.resolve() to provide the correct path to requireTaskPool.

This is a problem for Webpack users because Webpack rewrites
require.resolve().

Removing require.resolve() enables Webpack users to use
electron-remote.

I'm not sure, but I think for some users who implicitly depend on the
current behavior of electron-remote require.resolve()-ing for them,
this may be a breaking change.